### PR TITLE
Add a main to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ngmap",
   "version": "1.1.6",
+  "main": "build/scripts/ng-map.js",
   "dependencies": {
     "gulp": "~3.7.0",
     "glob": "~4.0.2"


### PR DESCRIPTION
Adding a main section to the package.json for very simple browserify support. If the package is being pulled in using NPM (directly from the github repo as it is unpublished), this will allow browserify to find it.

Note this does not add proper module support, and references the non-minified file, assuming it will be part of a build process. The browser property could also be used instead if you prefer.

Full details: https://github.com/substack/node-browserify#packagejson
