### PR TITLE
Added $destroy event to delete directions directive when has been removed

### DIFF
--- a/app/scripts/directives/directions.js
+++ b/app/scripts/directives/directions.js
@@ -95,6 +95,9 @@
       scope.$on('mapInitialized', function(event, map) {
         updateRoute(renderer, options);
       });
+      scope.$on('$destroy', function(event, map) {
+        mapController.deleteObject('directionsRenderers', renderer);
+      });
     };
     
     return {


### PR DESCRIPTION
This is important when an user have more dynamic directives with ng-if or similars.