### PR TITLE
fix(events): pass through updated model values

### DIFF
--- a/app/scripts/services/attr2_options.js
+++ b/app/scripts/services/attr2_options.js
@@ -195,9 +195,9 @@
         var matches = attrValue.match(/([^\(]+)\(([^\)]*)\)/);
         var funcName = matches[1];
         var argsStr = matches[2].replace(/event[ ,]*/,'');  //remove string 'event'
-        
-        var args = scope.$eval("["+argsStr+"]");
+        var argsExpr = $parse("["+argsStr+"]"); //for perf when triggering event
         return function(event) {
+          var args = argsExpr(scope); //get args here to pass updated model values
           function index(obj,i) {return obj[i];}
           var f = funcName.split('.').reduce(index, scope);
           f && f.apply(this, [event].concat(args));

--- a/spec/services/attr2_options_spec.js
+++ b/spec/services/attr2_options_spec.js
@@ -100,6 +100,27 @@ describe('Attr2Options', function() {
       var events = parser.getEvents(scope, attrs);
       expect(typeof events.click).toEqual('function');
     });
+    it('should pass arguments to callback', function() {
+      scope.name = 'dave';
+      scope.scopeFunc = function() {}
+      var attrs ={onClick:'scopeFunc(name)'};
+      var events = parser.getEvents(scope, attrs);
+      var event = {};
+      spyOn(scope, 'scopeFunc');
+      events.click(event);
+      expect(scope.scopeFunc).toHaveBeenCalledWith(event, scope.name);
+    });
+    it('should respond to scope model changes', function() {
+      scope.name = 'dave';
+      scope.scopeFunc = function() {};
+      var attrs ={onClick:'scopeFunc(name)'};
+      var events = parser.getEvents(scope, attrs);
+      var event;
+      spyOn(scope, 'scopeFunc');
+      scope.name = 'george';
+      events.click(event);
+      expect(scope.scopeFunc).toHaveBeenCalledWith(event, scope.name);
+    });
   });
 
   describe("#getAttrsToObserve", function() {


### PR DESCRIPTION
The current behaviour is that event handlers will be
passed the value of each argument as it was at the time
the event handler was created, which is when the
directive is linked. This means an event handler being
passed args derived from the scope will not receive
any updated values.

This commit will alter the behaviour to send through
any updated model values.