### PR TITLE
bugfix to convert date in options hash to a Date object in Directions Request

### DIFF
--- a/services/attr2_options.js
+++ b/services/attr2_options.js
@@ -76,6 +76,10 @@
               return new google.maps.LatLng(output[0], output[1]);
             }
           }
+          else if (output === Object(output)) { // JSON is an object (not array or null)
+            // check for nested hashes and convert to Google API options
+            output = getOptions(output, options);
+          }
         } catch(err2) {
           // 3. Object Expression. i.e. LatLng(80,-49)
           if (input.match(/^[A-Z][a-zA-Z0-9]+\(.*\)$/)) {
@@ -103,6 +107,13 @@
               } else {
                 output = google.maps[capitalizedKey][input];
               }
+            } catch(e) {
+              output = input;
+            }
+          // 6. Date Object as ISO String i.e. "2015-08-12T06:12:40.858Z"
+          } else if (input.match(/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/)) {
+            try {
+              output = new Date(input);
             } catch(e) {
               output = input;
             }
@@ -172,7 +183,12 @@
           } else if (key.match(/ControlOptions$/)) { // skip controlOptions
             continue;
           } else {
-            options[key] = toOptionValue(attrs[key], {scope:scope, key: key});
+            // nested conversions need to be typechecked (non-strings are fully converted)
+            if (typeof attrs[key] !== 'string') {
+              options[key] = attrs[key];
+            } else {
+              options[key] = toOptionValue(attrs[key], {scope:scope, key: key});
+            }
           }
         } // if (attrs[key])
       } // for(var key in attrs)

--- a/spec/services/attr2_options_spec.js
+++ b/spec/services/attr2_options_spec.js
@@ -60,6 +60,20 @@ describe('Attr2Options', function() {
       attrs = {MapTypeId:'HYBRID'};
       expect(parser.getOptions(attrs, scope).MapTypeId).toEqual(google.maps.MapTypeId.HYBRID);
     });
+    it('should convert ISO date strings to Date objects', function() {
+      var attrs = {a:'2015-08-13T04:11:23.005Z'};
+      expect(parser.getOptions(attrs, scope).a instanceof Date).toBe(true);
+    });
+    it('should convert nested date to Date object', function() {
+      var attrs = {a: '{"departureTime":"2015-08-13T18:00:21.846Z"}'};
+      expect(typeof parser.getOptions(attrs, scope).a).toEqual('object');
+      expect(parser.getOptions(attrs, scope).a.departureTime instanceof Date).toEqual(true);
+    });
+    it('should convert nested value to google object', function() {
+      var attrs = {circleOptions: '{"center": "LatLng(80,-49)"}'};
+      expect(parser.getOptions(attrs, scope).circleOptions.center.lat()).toEqual(80);
+      expect(parser.getOptions(attrs, scope).circleOptions.center.lng()).toEqual(-49);
+    });
   });
 
   describe("#getControlOptions", function() {


### PR DESCRIPTION
See the issue here: http://jsfiddle.net/rjnqdLhf/1/

- According to Google's Maps API, the directions request can have a transitOptions property. This transitOptions object an have departureTime/arrivalTime property, which are expected to be Date objects.
- When passing the transitOptions object as an attribute to the directions directive, angular converts this date object to a string. This results in a request error when the Directions Request is made to the Google API.

-- The suggested solution remedies this error by passing JSON objects back through getOptions in Attr2Options, changing nested objects to Google API options using toOptionValue.