### PR TITLE
Remove external script reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ For Bower users,
 
 1. Include `ng-map.min.js` as well as google maps.  
     `<script src="http://maps.google.com/maps/api/js"></script>`  
-    `<script src="http://rawgit.com/allenhwkim/angularjs-google-maps/master/build/scripts/ng-map.min.js"></script>`
 
 2. name angular app as ngMap, or add it as a dependency
 


### PR DESCRIPTION
If user has the module installed, they are referencing that instead of the externally hosted one.