### PR TITLE
Fix for info window appearing on wrong marker

### DIFF
--- a/testapp/infowindow_ng_click.html
+++ b/testapp/infowindow_ng_click.html
@@ -23,7 +23,7 @@ angular.module('ngMap').controller('MyCtrl', function(NgMap) {
 
   vm.showDetail = function(e, shop) {
     vm.shop = shop;
-    vm.map.showInfoWindow('foo-iw', 'foo');
+    vm.map.showInfoWindow('foo-iw', shop.id);
   };
 
   vm.hideDetail = function() {


### PR DESCRIPTION
In this demo all info windows appear always on the marker named "foo". Using the clicked marker's id in showDetail makes it appears on the right marker.