### PR TITLE
Enable customMarkers to open Info Windows (by id)

### DIFF
--- a/directives/info-window.js
+++ b/directives/info-window.js
@@ -136,7 +136,19 @@
           var id = typeof p1 == 'string' ? p1 : p2;
           var marker = typeof p1 == 'string' ? p2 : p3;
           if (typeof marker == 'string') {
-            marker = mapController.map.markers[marker];
+            //Check if markers if defined to avoid odd 'undefined' errors
+            if (typeof mapController.map.markers != "undefined"
+                && typeof mapController.map.markers[marker] != "undefined") {
+              marker = mapController.map.markers[marker];
+            } else if (
+                //additionally check if that marker is a custom marker
+            typeof mapController.map.customMarkers
+            && typeof mapController.map.customMarkers[marker] != "undefined") {
+              marker = mapController.map.customMarkers[marker];
+            } else {
+              //Better error output if marker with that id is not defined
+              throw new Error("Cant open info window for id " + marker + ". Marker or CustomMarker is not defined")
+            }
           }
 
           var infoWindow = mapController.map.infoWindows[id];


### PR DESCRIPTION
Hello, 

I'm using custom markers (with dynamic ids) with info windows but there is no way to open info windows from custom markers, because the code does only check the markers object.

```html
   <custom-marker ng-repeat="device in vm.devices"
           id='device-marker-{{device.id}}'
           on-click="alarmCtrl.showDeviceDetail(device);"
           position="[{{device.position.lat}}, {{ device.position.lon }}]">

```
```javascript
    this.showDeviceDetail = function (e, objDevice) {
        vm.map.showInfoWindow('device-detail', "device-marker-" + objDevice.id);
    };
```

I need to make use of the dynamic ids, because i want to open the  info windows from the code in different locations.

Tests did pass