### PR TITLE
Add trigger resize to map initialization

### DIFF
--- a/controllers/map-controller.js
+++ b/controllers/map-controller.js
@@ -136,8 +136,8 @@
       // set objects for lazyInit
       if (lazyInitMap) {
 
-        /** 
-         * rebuild mapOptions for lazyInit 
+        /**
+         * rebuild mapOptions for lazyInit
          * becasue attributes values might have been changed
          */
         var filtered = Attr2MapOptions.filter($attrs);
@@ -150,7 +150,7 @@
           var groupMembers = lazyInitMap[group]; //e.g. markers
           if (typeof groupMembers == 'object') {
             for (var id in groupMembers) {
-              vm.addObject(group, groupMembers[id]); 
+              vm.addObject(group, groupMembers[id]);
             }
           }
         }
@@ -228,6 +228,11 @@
       NgMap.addMap(vm);
     } else {
       vm.initializeMap();
+    }
+
+    //Trigger Resize
+    if(options.triggerResize) {
+      google.maps.event.trigger(vm.map, 'resize');
     }
 
     $element.bind('$destroy', function() {

--- a/directives/map.js
+++ b/directives/map.js
@@ -9,7 +9,7 @@
  * Initialize a Google map within a `<div>` tag
  *   with given options and register events
  *
- * @attr {Expression} map-initialized 
+ * @attr {Expression} map-initialized
  *   callback function when map is initialized
  *   e.g., map-initialized="mycallback(map)"
  * @attr {Expression} geo-callback if center is an address or current location,
@@ -36,6 +36,8 @@
  *  When true the map will only display one info window at the time,
  *  if not set or false,
  *  everytime an info window is open it will be displayed with the othe one.
+ * @attr {Boolean} trigger-resize
+ *  Default to false.  Set to true to trigger resize of the map.  Needs to be done anytime you resize the map
  * @example
  * Usage:
  *   <map MAP_OPTIONS_OR_MAP_EVENTS ..>


### PR DESCRIPTION
The ability to trigger resize needs to be in the initialize map function.  The main controller does not know when the map is ready for a resize and so it is a guessing game with setTimeout.  This adds the ability to do <ng-map trigger-resize="true"