### PR TITLE
Draw Manager observing.  Allows you to bind to the options and change…

### DIFF
--- a/directives/drawing-manager.js
+++ b/directives/drawing-manager.js
@@ -56,6 +56,13 @@
           rectangleOptions:options.rectangleoptions
         });
 
+        //Observers
+        attrs.$observe('drawingControlOptions', function (newValue) {
+          drawingManager.drawingControlOptions = parser.getControlOptions({drawingControlOptions: newValue}).drawingControlOptions;
+          drawingManager.setDrawingMode(null);
+          drawingManager.setMap(mapController.map);
+        });
+
 
         /**
          * set events


### PR DESCRIPTION
… drawing modes.  For instance I only want one polygon to be drawn.  This allows me to splice out the polygon control and sets the drawing mode to null so it cannot be selected again.