### PR TITLE
[deleteMap] clear controllers only when is it defined

### DIFF
--- a/services/ng-map.js
+++ b/services/ng-map.js
@@ -88,9 +88,11 @@
   var deleteMap = function(mapCtrl) {
     var len = Object.keys(mapControllers).length - 1;
     var mapId = mapCtrl.map.id || len;
-    mapCtrl.map.controls.forEach(function(ctrl) {
-      ctrl.clear();
-    });
+    if (typeof mapCtrl.map.controls != "undefined") {
+        mapCtrl.map.controls.forEach(function(ctrl) {
+          ctrl.clear();
+        });
+    }
     //delete mapCtrl.map;
     delete mapControllers[mapId];
   };


### PR DESCRIPTION
To reproduce the issue just try to destroy a map with `lazy-init="true"` and is not yet initialized:
```
TypeError: Cannot read property 'forEach' of undefined
    at Object.deleteMap
```