### PR TITLE
Remove Heatmap Layers when map is deleted

### DIFF
--- a/services/ng-map.js
+++ b/services/ng-map.js
@@ -99,6 +99,14 @@
         });
       }
     }
+
+    //Remove Heatmap Layers
+    if (mapCtrl.map.heatmapLayers) {
+      Object.keys(mapCtrl.map.heatmapLayers).forEach(function (layer) {
+        mapCtrl.deleteObject('heatmapLayers', mapCtrl.map.heatmapLayers[layer]);
+      });
+    }
+
     delete mapControllers[mapId];
   };
 


### PR DESCRIPTION
I am not sure if you are keeping the heat map data around to be reused or not but in my application it is rendering a new heatmap on top of the previous one.  If this is intended you can close.