### PR TITLE
parsing handlebars expressions in ids before lazy init

### DIFF
--- a/controllers/map-controller.js
+++ b/controllers/map-controller.js
@@ -231,7 +231,14 @@
     vm.eventListeners = {};
 
     if (options.lazyInit) { // allows controlled initialization
-      vm.map = {id: $attrs.id}; //set empty, not real, map
+      // parse angular expression for dynamic ids
+      if (!!$attrs.id && $attrs.id.startsWith('{{') && $attrs.id.endsWith('}}')) {
+        var idExpression = $attrs.id.slice(2,-2);
+        var mapId = $parse(idExpression)($scope);
+      } else {
+        var mapId = $attrs.id;
+      }
+      vm.map = {id: mapId}; //set empty, not real, map
       NgMap.addMap(vm);
     } else {
       vm.initializeMap();


### PR DESCRIPTION
I want to use lazy init with dynamic map ids, but currently the map id is just read from the attribute rather than parsed in the scope if the map is initialized lazily. This did the trick for me, hopefully its something others would want to