### PR TITLE
Remove deprecated timeout option from example

### DIFF
--- a/testapp/map-lazy-load-params.html
+++ b/testapp/map-lazy-load-params.html
@@ -7,7 +7,7 @@
 var app = app || angular.module('myapp', ['ngMap']);
 app.controller('MyCtrl', function($timeout, NgMap) {
   var vm = this;
-  NgMap.getMap({timeout:5000}).then(function(map) {
+  NgMap.getMap().then(function(map) {
       vm.map = map;
     });
 


### PR DESCRIPTION
I was using this option, trying to affect loading behavior and banging my head against the wall until I saw it was removed from the service.

I didn't understand from the commit comment why it was removed, but hopefully this should prevent someone else from trying to use it.