### PR TITLE
New feature: Info window external template

### DIFF
--- a/directives/info-window.js
+++ b/directives/info-window.js
@@ -78,7 +78,7 @@
        * it must have a container element with ng-non-bindable
        */
       var template;
-      $q(function(resolve) {
+      var templatePromise = $q(function(resolve) {
         if (angular.isString(element)) {
           $templateRequest(element).then(function (requestedTemplate) {
             resolve(angular.element(requestedTemplate).wrap('<div>').parent());
@@ -98,21 +98,23 @@
       });
 
       infoWindow.__open = function(map, scope, anchor) {
-        $timeout(function() {
-          anchor && (scope.anchor = anchor);
-          var el = $compile(infoWindow.__template)(scope);
-          infoWindow.setContent(el[0]);
-          scope.$apply();
-          if (anchor && anchor.getPosition) {
-            infoWindow.open(map, anchor);
-          } else if (anchor && anchor instanceof google.maps.LatLng) {
-            infoWindow.open(map);
-            infoWindow.setPosition(anchor);
-          } else {
-            infoWindow.open(map);
-          }
-          var infoWindowContainerEl = infoWindow.content.parentElement.parentElement.parentElement;
-          infoWindowContainerEl.className = "ng-map-info-window";
+        templatePromise.then(function() {
+          $timeout(function() {
+            anchor && (scope.anchor = anchor);
+            var el = $compile(infoWindow.__template)(scope);
+            infoWindow.setContent(el[0]);
+            scope.$apply();
+            if (anchor && anchor.getPosition) {
+              infoWindow.open(map, anchor);
+            } else if (anchor && anchor instanceof google.maps.LatLng) {
+              infoWindow.open(map);
+              infoWindow.setPosition(anchor);
+            } else {
+              infoWindow.open(map);
+            }
+            var infoWindowContainerEl = infoWindow.content.parentElement.parentElement.parentElement;
+            infoWindowContainerEl.className = "ng-map-info-window";
+          });
         });
       };
 

--- a/directives/info-window.js
+++ b/directives/info-window.js
@@ -50,7 +50,7 @@
 (function() {
   'use strict';
 
-  var infoWindow = function(Attr2MapOptions, $compile, $timeout, $parse, NgMap)  {
+  var infoWindow = function(Attr2MapOptions, $compile, $templateCache, $timeout, $parse, NgMap)  {
     var parser = Attr2MapOptions;
 
     var getInfoWindow = function(options, events, element) {
@@ -115,11 +115,13 @@
       var options = parser.getOptions(filtered, {scope: scope});
       var events = parser.getEvents(scope, filtered);
 
+      var customTemplate = options.template ? angular.element($templateCache.get(options.template)).wrap('<div>').parent() : null ;
+
       var address;
       if (options.position && !(options.position instanceof google.maps.LatLng)) {
         address = options.position;
       }
-      var infoWindow = getInfoWindow(options, events, element);
+      var infoWindow = getInfoWindow(options, events, customTemplate || element);
       if (address) {
         NgMap.getGeoLocation(address).then(function(latlng) {
           infoWindow.setPosition(latlng);
@@ -194,7 +196,7 @@
 
   }; // infoWindow
   infoWindow.$inject =
-    ['Attr2MapOptions', '$compile', '$timeout', '$parse', 'NgMap'];
+    ['Attr2MapOptions', '$compile', '$templateCache', '$timeout', '$parse', 'NgMap'];
 
   angular.module('ngMap').directive('infoWindow', infoWindow);
 })();

--- a/directives/info-window.js
+++ b/directives/info-window.js
@@ -74,26 +74,28 @@
       }
 
       /**
-       * set template ane template-relate functions
+       * set template and template-related functions
        * it must have a container element with ng-non-bindable
        */
-      var templatePromise = $q.defer();
-
-      if (angular.isString(options.template)) {
-        $templateRequest(options.template).then(function () {
-          setup(angular.element(element).wrap('<div>').parent());
-        });
-      }
-      else {
-        setup(element);
-      }
-
-
-      var template = element.html().trim();
-      if (angular.element(template).length != 1) {
-        throw "info-window working as a template must have a container";
-      }
-      infoWindow.__template = template.replace(/\s?ng-non-bindable[='"]+/,"");
+      var template;
+      $q(function(resolve) {
+        if (angular.isString(element)) {
+          $templateRequest(element).then(function (requestedTemplate) {
+            resolve(angular.element(requestedTemplate).wrap('<div>').parent());
+          }, function(message) {
+            throw "info-window template request failed: " + message;
+          });
+        }
+        else {
+          resolve(element);
+        }
+      }).then(function(resolvedTemplate) {
+        template = resolvedTemplate.html().trim();
+        if (angular.element(template).length != 1) {
+          throw "info-window working as a template must have a container";
+        }
+        infoWindow.__template = template.replace(/\s?ng-non-bindable[='"]+/,"");
+      });
 
       infoWindow.__open = function(map, scope, anchor) {
         $timeout(function() {

--- a/directives/info-window.js
+++ b/directives/info-window.js
@@ -77,7 +77,6 @@
        * set template and template-related functions
        * it must have a container element with ng-non-bindable
        */
-      var template;
       var templatePromise = $q(function(resolve) {
         if (angular.isString(element)) {
           $templateRequest(element).then(function (requestedTemplate) {
@@ -90,7 +89,7 @@
           resolve(element);
         }
       }).then(function(resolvedTemplate) {
-        template = resolvedTemplate.html().trim();
+        var template = resolvedTemplate.html().trim();
         if (angular.element(template).length != 1) {
           throw "info-window working as a template must have a container";
         }

--- a/testapp/infowindow-template.html
+++ b/testapp/infowindow-template.html
@@ -10,23 +10,34 @@ app.controller('MyCtrl', function($compile, NgMap) {
   NgMap.getMap().then(function(map) {
     vm.map = map;
   });
-  vm.template = 'custom-external-template.html';
+  vm.template = {
+    cached: 'custom-cached-info-window-template.html',
+    external: '/testapp/partials/custom-info-window-template.html'
+  };
   vm.stores = {
-    foo: { position:[41, -87], items: [1,2,3,4]},
-    foo2: { position:[41, -80], items: [5,6,7,8]}
+    foo: {
+      position:[41, -87],
+      infoWindow: 'cached',
+      items: [1,2,3,4]
+    },
+    foo2: {
+      position:[41, -80],
+      infoWindow: 'external',
+      items: [5,6,7,8]
+    }
   };
   vm.showStore = function(evt, storeId) {
     vm.store = vm.stores[storeId];
-    vm.map.showInfoWindow('foo', this);
+    vm.map.showInfoWindow(vm.store.infoWindow, this);
   };
 });
 </script>
 </head>
 <body ng-controller="MyCtrl as vm">
 
-  <script id="custom-external-template.html" type="text/ng-template">
+  <script id="custom-cached-info-window-template.html" type="text/ng-template">
       <div ng-non-bindable="">
-        I'm an external template<br/>
+        I'm an cached template<br/>
         Lat: {{anchor.getPosition().lat()}}<br/>
         Lng: {{anchor.getPosition().lng()}}<br>
         <ul>
@@ -37,7 +48,8 @@ app.controller('MyCtrl', function($compile, NgMap) {
 
   <ng-map default-style="true" center="41,-87" zoom="3">
 
-    <info-window id="foo" template="{{vm.template}}"></info-window>
+    <info-window id="cached" template="{{vm.template.cached}}"></info-window>
+    <info-window id="external" template="{{vm.template.external}}"></info-window>
 
     <marker ng-repeat="(id, store) in vm.stores" id="{{id}}"
       position="{{store.position}}"

--- a/testapp/infowindow-template.html
+++ b/testapp/infowindow-template.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html ng-app="myapp">
+<head>
+<meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+<script src="script-tags-for-development.js"></script>
+<script>
+var app = app || angular.module('myapp', ['ngMap']);
+app.controller('MyCtrl', function($compile, NgMap) {
+  var vm = this;
+  NgMap.getMap().then(function(map) {
+    vm.map = map;
+  });
+  vm.template = 'custom-external-template.html';
+  vm.stores = {
+    foo: { position:[41, -87], items: [1,2,3,4]},
+    foo2: { position:[41, -80], items: [5,6,7,8]}
+  };
+  vm.showStore = function(evt, storeId) {
+    vm.store = vm.stores[storeId];
+    vm.map.showInfoWindow('foo', this);
+  };
+});
+</script>
+</head>
+<body ng-controller="MyCtrl as vm">
+
+  <script id="custom-external-template.html" type="text/ng-template">
+      <div ng-non-bindable="">
+        I'm an external template<br/>
+        Lat: {{anchor.getPosition().lat()}}<br/>
+        Lng: {{anchor.getPosition().lng()}}<br>
+        <ul>
+          <li ng-repeat='item in vm.store.items'>{{item}}</li>
+        </ul>
+      </div>
+  </script>
+
+  <ng-map default-style="true" center="41,-87" zoom="3">
+
+    <info-window id="foo" template="{{vm.template}}"></info-window>
+
+    <marker ng-repeat="(id, store) in vm.stores" id="{{id}}"
+      position="{{store.position}}"
+      on-click="vm.showStore(event, id)"></marker>
+  </ng-map>
+</body>
+</html>

--- a/testapp/partials/custom-info-window-template.html
+++ b/testapp/partials/custom-info-window-template.html
@@ -1,0 +1,8 @@
+<div ng-non-bindable="">
+	I'm an external template<br/>
+	Lat: {{anchor.getPosition().lat()}}<br/>
+	Lng: {{anchor.getPosition().lng()}}<br>
+	<ul>
+		<li ng-repeat='item in vm.store.items'>{{item}}</li>
+	</ul>
+</div>


### PR DESCRIPTION
This feature will allow you to have the content from the info window loaded from an external template using the ```$templateCache```.

I needed this method because I wrapped ```ng-map``` inside my own directive that serves as a reusable component. Dynamic template content turned out to be hard and this was the only way I could make this work as far as I know.

A demo can be viewed from file ```infowindow-template.html```.