### PR TITLE
Updated zoomToIncludeMarkers to only fit to bounds if there are markers

### DIFF
--- a/controllers/map-controller.js
+++ b/controllers/map-controller.js
@@ -95,17 +95,21 @@
      * @function zoomToIncludeMarkers
      */
     vm.zoomToIncludeMarkers = function() {
-      var bounds = new google.maps.LatLngBounds();
-      for (var k1 in vm.map.markers) {
-        bounds.extend(vm.map.markers[k1].getPosition());
+      // Only fit to bounds if we have any markers
+      // object.keys is supported in all major browsers (IE9+)
+      if ((vm.map.markers != null && Object.keys(vm.map.markers).length > 0) || (vm.map.customMarkers != null && Object.keys(vm.map.customMarkers).length > 0)) {
+        var bounds = new google.maps.LatLngBounds();
+        for (var k1 in vm.map.markers) {
+          bounds.extend(vm.map.markers[k1].getPosition());
+        }
+        for (var k2 in vm.map.customMarkers) {
+          bounds.extend(vm.map.customMarkers[k2].getPosition());
+        }
+    	  if (vm.mapOptions.maximumZoom) {
+    		  vm.enableMaximumZoomCheck = true; //enable zoom check after resizing for markers
+    	  }
+        vm.map.fitBounds(bounds);
       }
-      for (var k2 in vm.map.customMarkers) {
-        bounds.extend(vm.map.customMarkers[k2].getPosition());
-      }
-	  if (vm.mapOptions.maximumZoom) {
-		  vm.enableMaximumZoomCheck = true; //enable zoom check after resizing for markers
-	  }
-      vm.map.fitBounds(bounds);
     };
 
     /**


### PR DESCRIPTION
Currently when you have no markers the zoom-to-include-markers centers the map around geo coordinate 0,0 (at least I guess), see: http://plnkr.co/edit/uiif3eISQM1fg3kknvaz?p=preview for an example. This looks a bit weird if you init the map without markers or remove the markers after initialization.

This pull request makes sure that if you have no markers the default center location is used.

