### PR TITLE
Using an external template will add the ng-non-bindable attribute automatically

### DIFF
--- a/directives/info-window.js
+++ b/directives/info-window.js
@@ -80,7 +80,7 @@
       var templatePromise = $q(function(resolve) {
         if (angular.isString(element)) {
           $templateRequest(element).then(function (requestedTemplate) {
-            resolve(angular.element(requestedTemplate).wrap('<div>').parent());
+            resolve(angular.element(requestedTemplate).wrap('<div ng-non-bindable>').parent());
           }, function(message) {
             throw "info-window template request failed: " + message;
           });

--- a/testapp/partials/custom-info-window-template.html
+++ b/testapp/partials/custom-info-window-template.html
@@ -1,4 +1,4 @@
-<div ng-non-bindable="">
+<div>
 	I'm an external template<br/>
 	Lat: {{anchor.getPosition().lat()}}<br/>
 	Lng: {{anchor.getPosition().lng()}}<br>


### PR DESCRIPTION
I discovered that I received an error when I was trying to open the info-window using a external template (```info-window working as a template must have a container```). That was because I was missing a ```ng-non-bindable``` attribute.

But because the template is being wrapped within another div the attribute was missing. The wrapper now contains the attribute.

This even means you don't need to add the ```ng-non-bindable``` yourself anymore when using an external template.