### PR TITLE
startsWith and endsWith are not supported in IE < 12

### DIFF
--- a/controllers/map-controller.js
+++ b/controllers/map-controller.js
@@ -247,7 +247,11 @@
 
     if (options.lazyInit) { // allows controlled initialization
       // parse angular expression for dynamic ids
-      if (!!$attrs.id && $attrs.id.startsWith('{{') && $attrs.id.endsWith('}}')) {
+      if (!!$attrs.id && 
+      	  // starts with, at position 0
+	  $attrs.id.indexOf("{{", 0) === 0 &&
+	  // ends with
+	  $attrs.id.indexOf("}}", $attrs.id.length - "}}".length) !== -1) {
         var idExpression = $attrs.id.slice(2,-2);
         var mapId = $parse(idExpression)($scope);
       } else {


### PR DESCRIPTION
IE < 12 fails with the startsWith and endsWith lines (not supported).
See https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith

This change replaces the methods with logic that works in all browsers.