### PR TITLE
Fix for issue #670 "Custom markers disappear on second load"

### DIFF
--- a/directives/custom-marker.js
+++ b/directives/custom-marker.js
@@ -69,9 +69,9 @@
       position && (this.position = position); /* jshint ignore:line */
 
       if (this.getProjection() && typeof this.position.lng == 'function') {
-        var posPixel = this.getProjection().fromLatLngToDivPixel(this.position);
         var _this = this;
         var setPosition = function() {
+          var posPixel = _this.getProjection().fromLatLngToDivPixel(_this.position);
           var x = Math.round(posPixel.x - (_this.el.offsetWidth/2));
           var y = Math.round(posPixel.y - _this.el.offsetHeight - 10); // 10px for anchor
           _this.el.style.left = x + "px";


### PR DESCRIPTION
Moved calculation of final pixel coordinates for custom markers to the moment these are applied to the overlay's element to account for any changes in size that may occur during the 300ms of delay that this function has under some circumstances (Line 85).