### PR TITLE
Add the npm  install in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ To get the map instance use the `NgMap.getMap()` function
       });
     });
 
+For npm users, 
+
+  `$ npm install ngmap`
+
 For meteor users: https://atmospherejs.com/wormy/angularjs-google-maps
 
 Lazy Loading of Google Maps Javascript


### PR DESCRIPTION
When I first saw the documentation, I thought the module was added to bower, not in npm. To avoid that confusion, added the npm install command in docs. 