### PR TITLE
Allow fusion-tables-layer to be removed from map

### DIFF
--- a/directives/fusion-tables-layer.js
+++ b/directives/fusion-tables-layer.js
@@ -45,6 +45,9 @@
 
         var layer = getLayer(options, events);
         mapController.addObject('fusionTablesLayers', layer);
+        element.bind('$destroy', function() {
+          mapController.deleteObject('fusionTablesLayers', layer);
+        });
       }
      }; // return
   }]);


### PR DESCRIPTION
Fixes fusion-tables-layer not being removed with ng-if