### PR TITLE
Updates to Test Harness

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ var gutil = require('gulp-util');
 var tap = require('gulp-tap');
 var bump = require('gulp-bump');
 var shell = require('gulp-shell');
-var karma = require('karma').server;
+var karma = require('karma').Server;
 var connect = require('gulp-connect');
 var gulpProtractor = require("gulp-protractor").protractor;
 var File = require('vinyl');
@@ -168,10 +168,10 @@ gulp.task('build', function(callback) {
 });
 
 gulp.task('test', function (done) {
-  karma.start({
+  new karma({
     configFile: __dirname + '/config/karma.conf.js',
     singleRun: true
-  }, done);
+  }, done).start();
 });
 
 gulp.task('test:server',  function() {

--- a/spec/services/ng-map-pool-spec.js
+++ b/spec/services/ng-map-pool-spec.js
@@ -8,13 +8,6 @@ describe('NgMapPool', function() {
    beforeEach(inject(function ($rootScope, _NgMapPool_, _$window_) {
      scope = $rootScope;
      NgMapPool = _NgMapPool_, $window = _$window_;
-     $window.google = {
-       maps: {
-         Map: function() {
-          this.getDiv = function() {};
-         }
-       }
-     };
    }));
 
   describe("#getMapInstance #returnMapInstance", function() {


### PR DESCRIPTION
Note: this doesn’t fix any tests but stops some incidental errors from
running `gulp test`

- Update initialisation of karma as per
https://github.com/karma-runner/gulp-karma. Avoids a deprecation
warning.

- Remove initialisation of global google object in ng-map-pool-spec. I
confess I don’t know what this is trying to achieve but it caused this
error “TypeError: undefined is not a constructor (evaluating
'google.maps.__gjsload__’)”. And this triggered “Unhandled rejection
Error” during PhantomJS shutdown.