### PR TITLE
Fixed issue that can cause the transclusion template to be overwritten.

### DIFF
--- a/directives/custom-control.js
+++ b/directives/custom-control.js
@@ -39,8 +39,9 @@
      * build a custom control element
      */
     var customControlEl = element[0].parentElement.removeChild(element[0]);
-    var content = $transclude();
-    angular.element(customControlEl).append(content);
+    $transclude(scope, function(clone) {
+      angular.element(customControlEl).append(clone);
+    });
 
     /**
      * set events


### PR DESCRIPTION
My team ran into an issue with this customControl directive, where its transclusion template was getting overwritten, causing multiple instances of elements that should not have been duplicated.

For context, this happened in cases where the parent component, whose template included a `<custom-control></custom-control>` element, would initially be rendered, then would be destroyed (thanks to an ngIf condition), then be rendered a second time. When rendered the second time, the transclusion template would include duplicates of every element it contained.

This also held true if the process was repeated a third time (3 instances of each element in the template), a fourth time, and so on.

The code in this PR prevents the transclusion template from getting overwritten and duplicated.