### PR TITLE
Fix heatmap-layer.js nested prop

### DIFF
--- a/directives/heatmap-layer.js
+++ b/directives/heatmap-layer.js
@@ -31,7 +31,7 @@
          * set options
          */
         var options = parser.getOptions(filtered, {scope: scope});
-        options.data = $window[attrs.data] || scope[attrs.data];
+        options.data = $window[attrs.data] || parseScope(attrs.data, scope);
         if (options.data instanceof Array) {
           options.data = new google.maps.MVCArray(options.data);
         } else {
@@ -46,6 +46,13 @@
         console.log('heatmap-layer options', layer, 'events', events);
 
         mapController.addObject('heatmapLayers', layer);
+        
+        //helper get nexted path
+        function parseScope( path, obj ) {
+            return path.split('.').reduce( function( prev, curr ) {
+                return prev[curr];
+            }, obj || this );
+        }
       }
      }; // return
   }]);


### PR DESCRIPTION
Allows to the directive access to a nested property.
This problem happens when we are using a nested property like 'data.map.heathData' or more commonly when we are using the syntax 'controllerAs', adding a 'vm' variable or similar.

fix: https://github.com/allenhwkim/angularjs-google-maps/issues/835